### PR TITLE
drm: Reduce latency while processing atomic ioctls

### DIFF
--- a/drivers/gpu/drm/drm_atomic.c
+++ b/drivers/gpu/drm/drm_atomic.c
@@ -32,6 +32,7 @@
 #include <drm/drm_print.h>
 #include <linux/sync_file.h>
 #include <linux/devfreq_boost.h>
+#include <linux/pm_qos.h>
 
 #include "drm_crtc_internal.h"
 
@@ -2205,8 +2206,8 @@ static void complete_crtc_signaling(struct drm_device *dev,
 	kfree(fence_state);
 }
 
-int drm_mode_atomic_ioctl(struct drm_device *dev,
-			  void *data, struct drm_file *file_priv)
+static int __drm_mode_atomic_ioctl(struct drm_device *dev, void *data,
+				   struct drm_file *file_priv)
 {
 	struct drm_mode_atomic *arg = data;
 	uint32_t __user *objs_ptr = (uint32_t __user *)(unsigned long)(arg->objs_ptr);
@@ -2374,5 +2375,25 @@ out:
 	drm_modeset_drop_locks(&ctx);
 	drm_modeset_acquire_fini(&ctx);
 
+	return ret;
+}
+
+int drm_mode_atomic_ioctl(struct drm_device *dev, void *data,
+			  struct drm_file *file_priv)
+{
+	/*
+	 * Optimistically assume the current task won't migrate to another CPU
+	 * and restrict the current CPU to shallow idle states so that it won't
+	 * take too long to finish running the ioctl whenever the ioctl runs a
+	 * command that sleeps, such as for an "atomic" commit.
+	 */
+	struct pm_qos_request req = {
+		.type = PM_QOS_REQ_AFFINE_CORES,
+		.cpus_affine = ATOMIC_INIT(BIT(raw_smp_processor_id()))
+	};
+	int ret;
+	pm_qos_add_request(&req, PM_QOS_CPU_DMA_LATENCY, 100);
+	ret = __drm_mode_atomic_ioctl(dev, data, file_priv);
+	pm_qos_remove_request(&req);
 	return ret;
 }


### PR DESCRIPTION
Unfortunately, our display driver must occasionally sleep inside start_atomic(), which causes the CPU running the ioctl to schedule and potentially idle. Depending on how deeply the running CPU idles, there can be quite a bit of latency added to processing the "atomic" ioctl as a result, which hurts display rendering latency. We can alleviate this by optimistically assuming that the task running the ioctl won't migrate CPUs while it runs and restricting the current CPU to shallow idle states.