### PR TITLE
Revert "mm: Never allow allocations more than our physical memory"

### DIFF
--- a/mm/util.c
+++ b/mm/util.c
@@ -576,8 +576,8 @@ int __page_mapcount(struct page *page)
 }
 EXPORT_SYMBOL_GPL(__page_mapcount);
 
-int sysctl_overcommit_memory __read_mostly = OVERCOMMIT_NEVER;
-int sysctl_overcommit_ratio __read_mostly = 100;
+int sysctl_overcommit_memory __read_mostly = OVERCOMMIT_GUESS;
+int sysctl_overcommit_ratio __read_mostly = 50;
 unsigned long sysctl_overcommit_kbytes __read_mostly;
 int sysctl_max_map_count __read_mostly = DEFAULT_MAX_MAP_COUNT;
 unsigned long sysctl_user_reserve_kbytes __read_mostly = 1UL << 17; /* 128MB */


### PR DESCRIPTION
This reverts commit a1f75bab4316e35b5888d414ba3e41ecde348943.